### PR TITLE
Upgrade Spring libraries to be compatible with CSpace 8.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # cspace-public-gateway
 
-A (prototype) gateway server for accessing public CollectionSpace data. This middleware allows limited anonymous (unauthenticated) access to a back-end Elasticsearch API and CollectionSpace REST API.
+An API gateway for accessing public CollectionSpace data. This middleware allows limited anonymous (unauthenticated) access to a back-end Elasticsearch API and CollectionSpace REST API.
 
 ## Building
 
-The program may be built as a war to be installed in a CollectionSpace tomcat server, or as an executable jar containing an embedded tomcat server.
-
-### To build as a war (default):
+The program may be built as a war to be installed in a CollectionSpace tomcat server.
 
 ```bash
 git clone https://github.com/collectionspace/cspace-public-gateway.git
@@ -16,37 +14,12 @@ mvn clean package [-Dpackaging=war]
 
 This produces org.collectionspace.publicbrowser-{version}.war in the target directory. The war file may be installed into a CollectionSpace tomcat server by copying it into the server's webapps directory.
 
-### To build as a jar:
-
-```bash
-git clone https://github.com/collectionspace/cspace-public-gateway.git
-cd cspace-public-gateway
-mvn clean package -Dpackaging=jar
-```
-
-This produces org.collectionspace.publicbrowser-{version}.jar in the target directory. The jar file may be copied to a server, and executed with `java -jar`.
-
 ## Running
-
-### Running the war:
 
 Copy the war into the webapps directory of a CollectionSpace tomcat server. The war is specifically packaged to run in the tomcat that is delivered as part of a standard CollectionSpace installation, and assumes the presence of libraries that are part of that installation. The application may not run in other tomcat installations.
 
 To configure the application, supply external properties using one of the [configuration methods supported by Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html).
 The available properties are listed in the default [application.yml](./src/main/resources/application.yml) file. Some properties (for example, port number) do not apply when the application is run as a war in an external tomcat.
-
-### Running the jar:
-
-The jar includes an embedded Tomcat server.
-
-```bash
-java -jar org.collectionspace.publicbrowser-{version}.jar
-```
-
-To configure the application, including the port on which it listens, supply external properties using one of the [configuration methods supported by Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html).
-The available properties are listed in the default [application.yml](./src/main/resources/application.yml) file.
-
-To run the application as a service using init.d or systemd, follow the [Spring Boot installation instructions](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html).
 
 ## Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
 
 	<groupId>org.collectionspace.publicbrowser</groupId>
 	<artifactId>org.collectionspace.publicbrowser</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<packaging>${packaging}</packaging>
+	<version>2.0.0-SNAPSHOT</version>
+	<packaging>war</packaging>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.12.RELEASE</version>
+		<version>2.2.13.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-zuul</artifactId>
+			<artifactId>spring-cloud-starter-netflix-zuul</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -58,10 +58,12 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-config</artifactId>
+			<version>5.8.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
+			<version>5.8.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.openfeign</groupId>
@@ -71,7 +73,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.13</version>
+			<version>1.25</version>
 		</dependency>
 	</dependencies>
 
@@ -80,9 +82,18 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Edgware.SR3</version>
+				<version>Hoxton.SR12</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<!--
+					CSpace 8 is using spring-web 5.3, which has an API incompatibility with 5.2 specified by
+					spring-boot-starter-web 2.2.13. Force 5.3.28 to be used.
+				-->
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-web</artifactId>
+				<version>5.3.28</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -140,79 +151,67 @@
 					<dependency>
 						<groupId>com.fasterxml.jackson.core</groupId>
 						<artifactId>jackson-databind</artifactId>
-						<version>2.8.0</version>
+						<version>2.14.3</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>com.fasterxml.jackson.core</groupId>
 						<artifactId>jackson-annotations</artifactId>
-						<version>2.8.0</version>
+						<version>2.14.3</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>com.fasterxml.jackson.core</groupId>
 						<artifactId>jackson-core</artifactId>
-						<version>2.8.0</version>
+						<version>2.14.3</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-aop</artifactId>
-						<version>4.3.16.RELEASE</version>
+						<version>5.3.28</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-beans</artifactId>
-						<version>4.3.16.RELEASE</version>
+						<version>5.3.28</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-context</artifactId>
-						<version>4.3.16.RELEASE</version>
+						<version>5.3.28</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-core</artifactId>
-						<version>4.3.16.RELEASE</version>
+						<version>5.3.28</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-web</artifactId>
-						<version>4.3.16.RELEASE</version>
-						<scope>provided</scope>
-					</dependency>
-					<dependency>
-						<groupId>org.springframework</groupId>
-						<artifactId>spring-webmvc</artifactId>
-						<version>4.3.16.RELEASE</version>
+						<version>5.3.28</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>spring-expression</artifactId>
-						<version>4.3.16.RELEASE</version>
+						<version>5.3.28</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework.security</groupId>
 						<artifactId>spring-security-config</artifactId>
-						<version>4.2.5.RELEASE</version>
+						<version>5.8.4</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.springframework.security</groupId>
 						<artifactId>spring-security-web</artifactId>
-						<version>4.2.5.RELEASE</version>
-						<scope>provided</scope>
-					</dependency>
-					<dependency>
-						<groupId>javax.validation</groupId>
-						<artifactId>validation-api</artifactId>
-						<version>1.1.0.Final</version>
+						<version>5.8.4</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
@@ -224,13 +223,13 @@
 					<dependency>
 						<groupId>org.apache.logging.log4j</groupId>
 						<artifactId>log4j-api</artifactId>
-						<version>2.17.0</version>
+						<version>2.17.1</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.logging.log4j</groupId>
 						<artifactId>log4j-core</artifactId>
-						<version>2.17.0</version>
+						<version>2.17.1</version>
 						<scope>provided</scope>
 					</dependency>
 					<dependency>
@@ -248,21 +247,35 @@
 					<dependency>
 						<groupId>org.yaml</groupId>
 						<artifactId>snakeyaml</artifactId>
+						<version>1.25</version>
+						<scope>provided</scope>
+					</dependency>
+					<dependency>
+						<groupId>jakarta.validation</groupId>
+						<artifactId>jakarta.validation-api</artifactId>
+						<version>2.0.2</version>
+						<scope>provided</scope>
+					</dependency>
+					<dependency>
+						<groupId>org.hibernate.validator</groupId>
+						<artifactId>hibernate-validator</artifactId>
+						<version>6.0.22.Final</version>
+						<scope>provided</scope>
+					</dependency>
+					<dependency>
+						<groupId>org.jboss.logging</groupId>
+						<artifactId>jboss-logging</artifactId>
+						<version>3.4.1.Final</version>
+						<scope>provided</scope>
+					</dependency>
+					<dependency>
+						<groupId>com.fasterxml</groupId>
+						<artifactId>classmate</artifactId>
+						<version>1.5.1</version>
 						<scope>provided</scope>
 					</dependency>
 				</dependencies>
 			</dependencyManagement>
-		</profile>
-
-		<profile>
-			<id>packaging-jar</id>
-
-			<activation>
-				<property>
-					<name>packaging</name>
-					<value>jar</value>
-				</property>
-			</activation>
 		</profile>
 	</profiles>
 </project>

--- a/src/main/java/org/collectionspace/publicbrowser/Gateway.java
+++ b/src/main/java/org/collectionspace/publicbrowser/Gateway.java
@@ -10,10 +10,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.web.server.WebServerFactory;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.cors.CorsConfiguration;
@@ -34,8 +34,8 @@ public class Gateway extends SpringBootServletInitializer {
 	}
 
 	@Bean
-	public EmbeddedServletContainerFactory servletContainer() {
-			TomcatEmbeddedServletContainerFactory tomcat = new TomcatEmbeddedServletContainerFactory();
+	public WebServerFactory servletContainer() {
+			TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
 
 			if (ajpPort != null) {
 				log.info(String.format("Adding Tomcat AJP connector on port %d", ajpPort));
@@ -69,7 +69,7 @@ public class Gateway extends SpringBootServletInitializer {
 		CorsConfiguration config = new CorsConfiguration();
 
 		config.setAllowCredentials(true);
-		config.addAllowedOrigin("*");
+		config.addAllowedOriginPattern("*");
 		config.addAllowedHeader("*");
 		config.addAllowedMethod("*");
 

--- a/src/main/java/org/collectionspace/publicbrowser/filter/CollectionSpaceQueryFilter.java
+++ b/src/main/java/org/collectionspace/publicbrowser/filter/CollectionSpaceQueryFilter.java
@@ -4,6 +4,7 @@ import com.netflix.util.Pair;
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.ZuulFilter;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,6 +17,7 @@ import org.collectionspace.publicbrowser.request.CollectionSpaceRequestWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.support.FilterConstants;
 import org.springframework.core.env.Environment;
 
@@ -160,6 +162,18 @@ public class CollectionSpaceQueryFilter extends ZuulFilter {
 	}
 
 	private void setupRequest(RequestContext context, String proxyId, HttpServletRequest request) {
+		if (context.containsKey(ProxyRequestHelper.IGNORED_HEADERS)) {
+			// Remove Authorization from ignored headers, so we can send the configured credentials.
+
+			Object object = context.get(ProxyRequestHelper.IGNORED_HEADERS);
+
+			if (object instanceof Collection) {
+				Collection<?> ignoredHeaders = (Collection<?>) object;
+
+				ignoredHeaders.remove("authorization");
+			}
+		}
+
 		String username = environment.getProperty("zuul.routes." + proxyId + ".username");
 		String password = environment.getProperty("zuul.routes." + proxyId + ".password");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,11 +49,6 @@ es:
   allowedPublishToValues: cspacepub,all
 
 zuul:
-  # By default authorization is a sensitive header that won't be passed downstream. Remove it, so
-  # we can send credentials.
-  sensitiveHeaders: Cookie,Set-Cookie
-  ignoredHeaders: Access-Control-Allow-Credentials,Access-Control-Allow-Origin
-
   # routes:
   #   core-cspace-services:
   #     path: /core/cspace-services/**


### PR DESCRIPTION
This upgrades Spring libraries to versions that are compatible with Spring used in cspace services. This is needed, because this webapp can be installed in the same tomcat container as the services, and some Spring libraries will end up being shared.

This also remove the jar packaging (embedded tomcat) option, as this doesn't work with the particular combination of Spring libraries now we have to use.